### PR TITLE
add go-generate-fast so we can use it in ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.23.4-alpine
 RUN apk add git npm --no-cache  && apk cache clean \
 	&& go install github.com/go-task/task/v3/cmd/task@latest \
 	&& go install entgo.io/ent/cmd/ent@latest \
+	&& go install github.com/oNaiPs/go-generate-fast@latest \ 
 	&& npm install jsonschema2mk --global
 
 ADD https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh /tmp/install.sh


### PR DESCRIPTION
since we are using mostly self-hosted runners, we should be able to use a cache to help speed up this in our pipelines