### PR TITLE
feat: add rover cli to build image

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -7,3 +7,5 @@ AVD-DS-0002
 CVE-2021-38561
 # github.com/zclconf/go-cty v1.8.0 // indirect
 CVE-2020-29652
+# golang.org/x/net
+CVE-2024-45338

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM golang:1.23.4-alpine
 RUN apk add git npm --no-cache  && apk cache clean \
 	&& go install github.com/go-task/task/v3/cmd/task@latest \
 	&& go install entgo.io/ent/cmd/ent@latest \
-	&& npm install jsonschema2mk --global
+	&& npm install jsonschema2mk --global \
+	&& npm install @apollo/rover --global
 
 ADD https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh /tmp/install.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.23.4-alpine
 
 RUN apk add git npm --no-cache  && apk cache clean \
-	&& go install github.com/go-task/task/v3/cmd/task@latest \
+	&& go install github.com/go-task/task/v3/cmd/task@main \
 	&& go install entgo.io/ent/cmd/ent@latest \
 	&& npm install jsonschema2mk --global \
 	&& npm install @apollo/rover --global


### PR DESCRIPTION
Adds the `rover` cli so we can publish the graph schema in buildkite, e.g.:


```
docker run  docker.io/library/base-ci-image:dev rover graph publish

  --schema <SCHEMA>
  <GRAPH_REF>

Usage: rover-0.26.3 graph publish --schema <SCHEMA> <GRAPH_REF>
```

- Adds high vuln to trivy ignore because upstream are not updated yet
- Updates task install to main to fix the critical vuln with the `crypto` package 